### PR TITLE
front/feat: Art 페이지 ui 구현

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -14,6 +14,7 @@
         "rc-picker": "^4.7.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-icons": "^5.3.0",
         "react-router-dom": "^6.27.0",
         "run": "^1.5.0"
       },
@@ -5397,6 +5398,14 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
+      "integrity": "sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
     "rc-picker": "^4.7.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-icons": "^5.3.0",
     "react-router-dom": "^6.27.0",
     "run": "^1.5.0"
   },

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -9,7 +9,18 @@
   --primary-container: #f2f6f0;
   --secondary: #dcf2ff;
   --gray-500: #777986;
+  --black: #252525;
   --shadow: 0px 0px 16px rgba(37, 37, 37, 0.1);
+}
+
+.layout {
+  width: 402px;
+  height: 874px;
+  margin: auto;
+  background: var(--secondary);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .shadow-box {

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,18 +1,15 @@
 #root {
   max-width: 1280px;
   margin: 0 auto;
-  padding: 2rem;
   text-align: center;
 }
 
 :root {
   --primary: #4f9273;
-  --primary-container: #dcf2ff;
-  --secondary: #f2f6f0;
-
+  --primary-container: #f2f6f0;
+  --secondary: #dcf2ff;
   --gray-500: #777986;
-
-  --shadow: rgba(0, 0, 0, 0.2);
+  --shadow: 0px 0px 16px rgba(37, 37, 37, 0.1);
 }
 
 .shadow-box {

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -17,6 +17,7 @@
   width: 402px;
   height: 874px;
   margin: auto;
+  padding: 40px 24px 40px 24px;
   background: var(--secondary);
   display: flex;
   flex-direction: column;

--- a/client/src/components/common/CustomButton.tsx
+++ b/client/src/components/common/CustomButton.tsx
@@ -17,7 +17,9 @@ export default function CustomButton({ text }: CustomButtonProps) {
         boxShadow: 'var(--shadow)',
       }}
     >
-      {text}
+      <span className="subtitle" style={{ color: 'white' }}>
+        {text}
+      </span>
     </Button>
   );
 }

--- a/client/src/components/common/CustomButton.tsx
+++ b/client/src/components/common/CustomButton.tsx
@@ -12,6 +12,9 @@ export default function CustomButton({ text }: CustomButtonProps) {
       style={{
         height: '48px',
         width: '354px',
+        backgroundColor: 'var(--primary)',
+        borderRadius: '10px',
+        boxShadow: 'var(--shadow)',
       }}
     >
       {text}

--- a/client/src/components/common/QuestContainer.tsx
+++ b/client/src/components/common/QuestContainer.tsx
@@ -9,7 +9,9 @@ interface TextContainerProps {
 export default function QuestContainer({ content }: TextContainerProps) {
   return (
     <div style={{ width: '354px', height: '140px', padding: '16px', backgroundColor: 'var(--primary-container)', borderRadius: '10px', boxShadow: 'var(--shadow)' }}>
-      <Text className="title">{content}</Text>
+      <Text className="title" style={{ color: 'var(--black)' }}>
+        {content}
+      </Text>
     </div>
   );
 }

--- a/client/src/components/common/QuestContainer.tsx
+++ b/client/src/components/common/QuestContainer.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Typography } from 'antd';
 
 const { Text } = Typography;
@@ -9,7 +8,7 @@ interface TextContainerProps {
 
 export default function QuestContainer({ content }: TextContainerProps) {
   return (
-    <div style={{ width: '354px', height: '140px', padding: '16px', backgroundColor: '#F2F6F0', borderRadius: '8px', boxShadow: '0px 0px 16px rgba(37, 37, 37, 0.1)' }}>
+    <div style={{ width: '354px', height: '140px', padding: '16px', backgroundColor: 'var(--primary-container)', borderRadius: '10px', boxShadow: 'var(--shadow)' }}>
       <Text className="title">{content}</Text>
     </div>
   );

--- a/client/src/components/common/Spacer.tsx
+++ b/client/src/components/common/Spacer.tsx
@@ -1,0 +1,9 @@
+interface SpacerProps {
+  height: number;
+}
+
+const Spacer: React.FC<SpacerProps> = ({ height }) => {
+  return <div style={{ height: `${height}px` }} />;
+};
+
+export default Spacer;

--- a/client/src/pages/ArtPage.tsx
+++ b/client/src/pages/ArtPage.tsx
@@ -1,0 +1,57 @@
+import { Layout } from 'antd';
+import { FaCamera } from 'react-icons/fa';
+
+import QuestContainer from '../components/common/QuestContainer';
+import { questions } from '../utils/constants';
+import CustomButton from '../components/common/CustomButton';
+import Spacer from '../components/common/Spacer';
+
+const ArtPage = () => {
+  return (
+    <Layout className="layout">
+      <QuestContainer content={questions[0]} />
+      <Spacer height={40} />
+
+      <p className="title self-start" color="var(--black)">
+        사진을 찍어주세요
+      </p>
+      <Spacer height={16} />
+
+      <div className="flex justify-center items-center" style={{ width: '354px', height: '354px', backgroundColor: 'var(--primary-container)', borderRadius: '10px', boxShadow: 'var(--shadow)' }}>
+        <FaCamera size={64} color="var(--primary)" />
+      </div>
+      <Spacer height={40} />
+
+      <p className="title self-start" color="var(--black)">
+        어떤 생각이 들었나요?
+      </p>
+      <Spacer height={16} />
+
+      <div style={{ width: '354px', height: '140px', padding: '16px', backgroundColor: 'var(--primary-container)', borderRadius: '10px', boxShadow: 'var(--shadow)' }}>
+        <textarea
+          maxLength={255}
+          placeholder="소감을 간단하게 적어주세요"
+          style={{
+            width: '100%',
+            height: '100%',
+            border: 'none',
+            outline: 'none',
+            backgroundColor: 'transparent',
+            fontSize: '14px',
+            resize: 'none',
+          }}
+        />
+      </div>
+      <Spacer height={8} />
+
+      <p className="body self-end" color="var(--gray-500)">
+        0/255
+      </p>
+      <Spacer height={24} />
+
+      <CustomButton text="저장" />
+    </Layout>
+  );
+};
+
+export default ArtPage;

--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -1,12 +1,14 @@
 import { Route, Routes } from 'react-router-dom';
 import { LoginPage } from '../pages/userLogin';
 import HomePage from '../pages/HomePage';
+import ArtPage from '../pages/ArtPage';
 
 export function RouteComponent() {
   return (
     <Routes>
       <Route path="/" element={<HomePage />} />
       <Route path="login" element={<LoginPage />} />
+      <Route path="art" element={<ArtPage />} />
     </Routes>
   );
 }

--- a/client/src/utils/constants.ts
+++ b/client/src/utils/constants.ts
@@ -1,4 +1,4 @@
-const questions: string[] = [
+export const questions: string[] = [
   '빨강, 주황, 노랑, 초록이 모두 있는 단풍 사진을 찍어보세요.',
   '오늘의 달은 어떤 모양이였나요?',
   '단풍에 맞춰 빨간 옷을 입어보아요!',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,50 @@
+{
+  "name": "inthon",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "react-icons": "^5.3.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "peer": true
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "peer": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
+      "integrity": "sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "react-icons": "^5.3.0"
+  }
+}


### PR DESCRIPTION
Art 페이지 ui 만들었습니다.
- 아직 변수 추가 안했음

css 변수 처리해서 적용시켜 두었습니다. 
- Layout에 `className=layout` 적용하면 기본 페이지 레이아웃 적용됩니다.
- `Spacer` 사용해서 빈 공간 생성 가능

<img width="397" alt="Screenshot 2024-11-09 at 7 37 52 PM" src="https://github.com/user-attachments/assets/34164922-7cea-4a9a-8859-4a4e1880af4b">
