### PR TITLE
front/feat: 공연 리스트 페이지 ui 구현

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -42,6 +42,11 @@
   box-shadow: var(--shadow);
 }
 
+.heading {
+  font-size: 24px;
+  font-weight: 700;
+}
+
 .title {
   font-size: 20px;
   font-weight: 600;

--- a/client/src/pages/PerformanceListPage.tsx
+++ b/client/src/pages/PerformanceListPage.tsx
@@ -1,0 +1,35 @@
+import { Layout, Row, Col } from 'antd';
+
+import poster from '../assets/poster.png';
+import Spacer from '../components/common/Spacer';
+
+const PerformanceListPage: React.FC = () => {
+  const handleCardClick = (index: number) => {
+    alert(`공연 ${index + 1}을 선택하셨습니다.`);
+  };
+  return (
+    <Layout className="layout">
+      <Spacer height={24} />
+      <p className="heading" color="var(--black)">
+        공연 정보
+      </p>
+      <Spacer height={24} />
+
+      <Row gutter={[24, 24]} justify="center">
+        {Array.from({ length: 6 }).map((_, index) => (
+          <Col key={index} style={{ padding: '0' }}>
+            <button onClick={() => handleCardClick(index)}>
+              <img src={poster} style={{ width: '160px', height: '231px', objectFit: 'contain' }} />
+              <Spacer height={16} />
+              <p className="subtitle" color="var(--black)">
+                MJ 매직 쇼
+              </p>
+            </button>
+          </Col>
+        ))}
+      </Row>
+    </Layout>
+  );
+};
+
+export default PerformanceListPage;

--- a/client/src/pages/PerformancePage.tsx
+++ b/client/src/pages/PerformancePage.tsx
@@ -7,13 +7,9 @@ import CustomButton from '../components/common/CustomButton';
 const PerformancePage = () => {
   return (
     <Layout className="layout">
-      <p className="title self-start" color="var(--black)">
-        MJ 매직쇼를 다녀오세요!
-      </p>
-      <Spacer height={24} />
       <img src={poster} style={{ width: '354px', height: 'auto' }} />
-      <Spacer height={24} />
-      <p className="subtitle self-start" color="var(--black)">
+      <Spacer height={40} />
+      <p className="title self-start" color="var(--black)">
         MJ 매직쇼
       </p>
       <Spacer height={8} />
@@ -24,7 +20,7 @@ const PerformancePage = () => {
       <p className="subtitle self-start" color="var(--black)">
         장소: 송파어린이문화회관 아이소리홀
       </p>
-      <Spacer height={40} />
+      <Spacer height={24} />
       <CustomButton text="기록하기" />
     </Layout>
   );

--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -5,6 +5,7 @@ import ArtPage from '../pages/ArtPage';
 import PerformancePage from '../pages/PerformancePage';
 import ButterflyPage from '../pages/ButterflyPage';
 import EggPage from '../pages/EggPage';
+import PerformanceListPage from '../pages/PerformanceListPage';
 
 export function RouteComponent() {
   return (
@@ -12,6 +13,7 @@ export function RouteComponent() {
       <Route path="/" element={<HomePage step={1} />} />
       <Route path="login" element={<LoginPage />} />
       <Route path="art" element={<ArtPage />} />
+      <Route path="performance-list" element={<PerformanceListPage />} />
       <Route path="performance" element={<PerformancePage />} />
       <Route path="butterfly" element={<ButterflyPage />} />
       <Route path="egg" element={<EggPage />} />


### PR DESCRIPTION
공연 리스트 페이지 ui 만들었습니다.   
공연 상세정보 페이지 ui 수정했습니다.

<img width="378" alt="Screenshot 2024-11-09 at 11 09 13 PM" src="https://github.com/user-attachments/assets/e9c24925-f3db-4fde-bb42-2a36add376db">
<img width="386" alt="Screenshot 2024-11-09 at 11 09 05 PM" src="https://github.com/user-attachments/assets/5d70ae4c-5d15-45fd-9eed-8cc17c2bcee9">
