### PR TITLE
back/feat: Performance 라우트 API 구현

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -34,12 +34,7 @@ import { AwsService } from './aws/aws.service';
     AwsModule,
     PerformanceModule,
   ],
-  controllers: [
-    AppController,
-    AuthController,
-    UserController,
-    PerformanceController,
-  ],
+  controllers: [AppController, AuthController, UserController],
   providers: [AppService, AuthService],
 })
 export class AppModule {}

--- a/server/src/performance/dtos/performance.dtos.ts
+++ b/server/src/performance/dtos/performance.dtos.ts
@@ -1,0 +1,5 @@
+export interface PerformanceGetAllResDto {
+  eventId: string;
+  prfNm: string;
+  poster: string;
+}

--- a/server/src/performance/dtos/performance.dtos.ts
+++ b/server/src/performance/dtos/performance.dtos.ts
@@ -1,5 +1,0 @@
-export interface PerformanceGetAllResDto {
-  eventId: string;
-  prfNm: string;
-  poster: string;
-}

--- a/server/src/performance/dtos/performance.req.dtos.ts
+++ b/server/src/performance/dtos/performance.req.dtos.ts
@@ -1,0 +1,3 @@
+export interface PerformanceGetReq {
+  eventId: string;
+}

--- a/server/src/performance/dtos/performance.res.dtos.ts
+++ b/server/src/performance/dtos/performance.res.dtos.ts
@@ -1,0 +1,15 @@
+export interface PerformanceGetAllResDto {
+  eventId: string;
+  prfNm: string;
+  poster: string;
+}
+
+export interface PerformanceGetResDto {
+  eventId: string;
+  prfNm: string;
+  prfStart: Date;
+  prfEnd: Date;
+  placeNm: string;
+  poster: string;
+  genreNm: string;
+}

--- a/server/src/performance/performance.controller.ts
+++ b/server/src/performance/performance.controller.ts
@@ -1,4 +1,15 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, Logger } from '@nestjs/common';
+import { PerformanceService } from './performance.service';
+import { PerformanceGetAllResDto } from './dtos/performance.dtos';
 
 @Controller('performance')
-export class PerformanceController {}
+export class PerformanceController {
+  constructor(private performanceService: PerformanceService) {}
+
+  private logger: Logger = new Logger('PerformanceController');
+  @Get('get-all')
+  async getAll(): Promise<PerformanceGetAllResDto[]> {
+    this.logger.log('Get all performance data');
+    return this.performanceService.getAll();
+  }
+}

--- a/server/src/performance/performance.controller.ts
+++ b/server/src/performance/performance.controller.ts
@@ -1,6 +1,17 @@
-import { Controller, Get, Logger } from '@nestjs/common';
+import {
+  BadRequestException,
+  Controller,
+  Get,
+  Logger,
+  Param,
+  Query,
+} from '@nestjs/common';
 import { PerformanceService } from './performance.service';
-import { PerformanceGetAllResDto } from './dtos/performance.dtos';
+import {
+  PerformanceGetAllResDto,
+  PerformanceGetResDto,
+} from './dtos/performance.res.dtos';
+import { PerformanceGetReq } from './dtos/performance.req.dtos';
 
 @Controller('performance')
 export class PerformanceController {
@@ -11,5 +22,16 @@ export class PerformanceController {
   async getAll(): Promise<PerformanceGetAllResDto[]> {
     this.logger.log('Get all performance data');
     return this.performanceService.getAll();
+  }
+
+  @Get('get')
+  async get(
+    @Query() performanceGetReq: PerformanceGetReq
+  ): Promise<PerformanceGetResDto> {
+    this.logger.log('Get performance data');
+    const eventId = performanceGetReq.eventId;
+    if (!eventId)
+      throw new BadRequestException('eventId가 전송되지 않았습니다.');
+    return this.performanceService.get(eventId);
   }
 }

--- a/server/src/performance/performance.entity.ts
+++ b/server/src/performance/performance.entity.ts
@@ -22,5 +22,5 @@ export class Performance extends CommonEntity {
   poster: string;
 
   @Column({ type: 'varchar', length: 31 })
-  genre: string;
+  genreNm: string;
 }

--- a/server/src/performance/performance.entity.ts
+++ b/server/src/performance/performance.entity.ts
@@ -1,6 +1,7 @@
-import { Column, PrimaryColumn } from 'typeorm';
+import { Column, Entity, PrimaryColumn } from 'typeorm';
 import { CommonEntity } from '../common/common.entity';
 
+@Entity('Performance')
 export class Performance extends CommonEntity {
   @PrimaryColumn({ type: 'varchar', length: 255 })
   eventId: string;

--- a/server/src/performance/performance.module.ts
+++ b/server/src/performance/performance.module.ts
@@ -2,9 +2,11 @@ import { Module } from '@nestjs/common';
 import { PerformanceService } from './performance.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Performance } from './performance.entity';
+import { PerformanceController } from './performance.controller';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Performance])],
   providers: [PerformanceService],
+  controllers: [PerformanceController],
 })
 export class PerformanceModule {}

--- a/server/src/performance/performance.service.ts
+++ b/server/src/performance/performance.service.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { LessThanOrEqual, MoreThanOrEqual, Repository } from 'typeorm';
 import { Performance } from './performance.entity';
+import { PerformanceGetAllResDto } from './dtos/performance.dtos';
 
 @Injectable()
 export class PerformanceService {
@@ -9,4 +10,17 @@ export class PerformanceService {
     @InjectRepository(Performance)
     private performanceRepository: Repository<Performance>
   ) {}
+
+  async getAll(): Promise<PerformanceGetAllResDto[]> {
+    const today = new Date();
+    console.log(today);
+    return this.performanceRepository.find({
+      select: ['eventId', 'prfNm', 'poster'],
+      where: {
+        prfEnd: MoreThanOrEqual(today),
+        prfStart: LessThanOrEqual(today),
+      },
+      take: 6,
+    });
+  }
 }

--- a/server/src/performance/performance.service.ts
+++ b/server/src/performance/performance.service.ts
@@ -2,7 +2,10 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { LessThanOrEqual, MoreThanOrEqual, Repository } from 'typeorm';
 import { Performance } from './performance.entity';
-import { PerformanceGetAllResDto } from './dtos/performance.dtos';
+import {
+  PerformanceGetAllResDto,
+  PerformanceGetResDto,
+} from './dtos/performance.res.dtos';
 
 @Injectable()
 export class PerformanceService {
@@ -13,7 +16,6 @@ export class PerformanceService {
 
   async getAll(): Promise<PerformanceGetAllResDto[]> {
     const today = new Date();
-    console.log(today);
     return this.performanceRepository.find({
       select: ['eventId', 'prfNm', 'poster'],
       where: {
@@ -21,6 +23,21 @@ export class PerformanceService {
         prfStart: LessThanOrEqual(today),
       },
       take: 6,
+    });
+  }
+
+  async get(eventId: string): Promise<PerformanceGetResDto> {
+    return this.performanceRepository.findOne({
+      select: [
+        'eventId',
+        'prfNm',
+        'prfStart',
+        'prfEnd',
+        'placeNm',
+        'poster',
+        'genreNm',
+      ],
+      where: { eventId },
     });
   }
 }


### PR DESCRIPTION
## 추가한 점
### performance/get-all
 - 해당 요청이 들어오면 6개의 공연/전시 정보를 응답한다.

### performance/get
 - Query로 eventId가 들어오면 해당 eventId를 가진 Performance 데이터를 PerformanceGetResDTO 형식에 맞추어 응답한다.
 - eventId가 query에 존재하지 않을 경우 400 BadRequestException 처리
 - 올바르지 않은 eventId가 query로 들어올 경우 예외처리 대신 200에 빈 배열을 반환하는 것으로 결정.