### PR TITLE
hotfix: nestjs 컨테이너 포트 열어주기

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,8 @@ services:
       dockerfile: Dockerfile
     env_file:
       - ./server/.env.dev
+    ports:
+      - "8501:8501"
     container_name: nest-backend
     networks:
       - inthon-bridge


### PR DESCRIPTION
## 수정한 점
- nestjs 컨테이너의 도커 컴포즈 구성 시 포트 열어줌