### PR TITLE
back/fix: enum 대신 entity에 check constraint 설정하는 것으로 변경

### DIFF
--- a/server/src/art/art.entity.ts
+++ b/server/src/art/art.entity.ts
@@ -6,17 +6,18 @@ import {
   OneToOne,
   ManyToOne,
   OneToMany,
+  Check,
 } from 'typeorm';
 import { Egg } from 'src/egg/egg.entity';
 
 @Entity('Art')
+@Check('"questionIdx" >= 0 AND "questionIdx" <= 6')
 export class Art extends CommonEntity {
   @PrimaryGeneratedColumn()
   id: number;
 
   @Column({
-    type: 'enum',
-    enum: [0, 1, 2, 3, 4, 5, 6], // 6: special question
+    type: 'int',
   })
   questionIdx: number;
 

--- a/server/src/egg/egg.entity.ts
+++ b/server/src/egg/egg.entity.ts
@@ -7,11 +7,13 @@ import {
   OneToMany,
   ManyToOne,
   JoinColumn,
+  Check,
 } from 'typeorm';
 import { Art } from 'src/art/art.entity';
 import { User } from 'src/user/user.entity';
 
 @Entity('Egg')
+@Check('"step" >= 0 AND "step" <= 3')
 export class Egg extends CommonEntity {
   constructor() {
     super();
@@ -22,8 +24,7 @@ export class Egg extends CommonEntity {
   id: number;
 
   @Column({
-    type: 'enum',
-    enum: [0, 1, 2, 3],
+    type: 'int',
     default: 0,
   })
   step: number;


### PR DESCRIPTION
## 수정한 점
- 더미 데이터 등을 insert할 때의 제약이 발생해서 `@Check`를 사용하기로 결정했습니다.